### PR TITLE
Instantiate dynamo clients once per call

### DIFF
--- a/src/clients.ts
+++ b/src/clients.ts
@@ -1,0 +1,40 @@
+import {DynamoDBClient} from '@aws-sdk/client-dynamodb';
+import {DynamoDBDocumentClient} from '@aws-sdk/lib-dynamodb';
+
+export type Credentials = {
+  accessKeyId: string;
+  secretAccessKey: string;
+  sessionToken: string;
+};
+
+const isTest = process.env.JEST_WORKER_ID;
+const endpoint = process.env.DYNAMODB_ENDPOINT;
+const region = process.env.REGION;
+
+export const ddbv3Client = (credentials?: Credentials) =>
+  new DynamoDBClient({
+    ...(isTest && {
+      endpoint: endpoint ?? 'http://localhost:8000',
+      tls: false,
+      region: region ?? 'local-env',
+    }),
+    credentials: getCredentials(credentials),
+  });
+
+export const ddbv3DocClient = (credentials?: Credentials) =>
+  DynamoDBDocumentClient.from(ddbv3Client(credentials));
+
+const getCredentials = (credentials?: Credentials) => {
+  if (credentials && Object.keys(credentials).length) {
+    return credentials;
+  }
+
+  if (isTest) {
+    return {
+      accessKeyId: 'fakeMyKeyId',
+      secretAccessKey: 'fakeSecretAccessKey',
+    };
+  }
+
+  return undefined;
+};

--- a/src/ddb.ts
+++ b/src/ddb.ts
@@ -16,8 +16,13 @@ export type Credentials = {
   secretAccessKey: string;
   sessionToken: string;
 };
-const ddbv3Client = (credentials?: Credentials) =>
-  new DynamoDBClient({
+
+let ddbClient;
+const ddbv3Client = (credentials?: Credentials) => {
+  if (ddbClient) {
+    return ddbClient;
+  }
+  ddbClient = new DynamoDBClient({
     ...(isTest && {
       endpoint: endpoint ?? 'http://localhost:8000',
       tls: false,
@@ -25,6 +30,8 @@ const ddbv3Client = (credentials?: Credentials) =>
     }),
     credentials: getCredentials(credentials),
   });
+  return ddbClient;
+}
 
 const getCredentials = (credentials?: Credentials) => {
   if (credentials && Object.keys(credentials).length) {
@@ -40,8 +47,15 @@ const getCredentials = (credentials?: Credentials) => {
 
   return undefined;
 };
-const ddbv3DocClient = (credentials?: Credentials) =>
-  DynamoDBDocumentClient.from(ddbv3Client(credentials));
+
+let ddbDocumentClient;
+const ddbv3DocClient = (credentials?: Credentials) => {
+  if (ddbDocumentClient) {
+    return ddbDocumentClient;
+  }
+  ddbDocumentClient = DynamoDBDocumentClient.from(ddbv3Client(credentials));
+  return ddbDocumentClient;
+}
 
 export function scan(
   params: ScanCommandInput,

--- a/src/ddb.ts
+++ b/src/ddb.ts
@@ -17,7 +17,7 @@ export type Credentials = {
   sessionToken: string;
 };
 
-let ddbClient;
+let ddbClient: DynamoDBClient;
 const ddbv3Client = (credentials?: Credentials) => {
   if (ddbClient) {
     return ddbClient;
@@ -48,7 +48,7 @@ const getCredentials = (credentials?: Credentials) => {
   return undefined;
 };
 
-let ddbDocumentClient;
+let ddbDocumentClient: DynamoDBDocumentClient;
 const ddbv3DocClient = (credentials?: Credentials) => {
   if (ddbDocumentClient) {
     return ddbDocumentClient;

--- a/src/parallel-scan-stream.ts
+++ b/src/parallel-scan-stream.ts
@@ -69,7 +69,6 @@ export async function parallelScanAsStream(
   return stream;
 }
 
-// eslint-disable-next-line complexity
 async function getItemsFromSegment({
   scanParams,
   stream,

--- a/src/parallel-scan.test.ts
+++ b/src/parallel-scan.test.ts
@@ -1,5 +1,6 @@
 import {insertMany} from './ddb';
 import {parallelScan} from './parallel-scan';
+import {ddbv3DocClient, ddbv3Client} from './clients';
 
 describe('parallelScan', () => {
   const files = [
@@ -16,7 +17,8 @@ describe('parallelScan', () => {
   ];
 
   beforeAll(async () => {
-    await insertMany({items: files, tableName: 'files'});
+    const docClient = ddbv3DocClient();
+    await insertMany({items: files, tableName: 'files'}, docClient);
   });
 
   it('should return all items with concurrency 1', async () => {


### PR DESCRIPTION
By instantiating the each time `scan` is called unnecessary overheads are used in terms of memory and open files.

In my case this was causing too many files open in AWS lambda.

By ensuring the client is only instantiated once each time I call this library the issue with too many files open was resolved.