### PR TITLE
Fix Max Call Stack Size Exceeded Issue

### DIFF
--- a/src/parallel-scan.ts
+++ b/src/parallel-scan.ts
@@ -40,7 +40,9 @@ export async function parallelScan(
         client: ddbClient,
       });
 
-      totalItems.push(...segmentItems!);
+      for (const segmentItem of segmentItems) {
+        totalItems.push(segmentItem);
+      }
       totalFetchedItemsCount += segmentItems!.length;
     })
   );
@@ -80,7 +82,9 @@ async function getItemsFromSegment(
     ExclusiveStartKey = LastEvaluatedKey;
     totalScannedItemsCount += ScannedCount!;
 
-    segmentItems.push(...Items!);
+    for (const item of Items) {
+      segmentItems.push(item);
+    }
 
     debug(
       `(${Math.round((totalScannedItemsCount / totalTableItemsCount) * 100)}%) ` +


### PR DESCRIPTION
* There can be issues with very large arrays when using `Array.push()` in conjunction with the spread operator. Specifically, it results in every element in the original array being pushed onto the call stack. Once the array gets huge, it will eventually result in the dreaded "Maximum call stack size exceeded" error. The fix for this is fairly simple: don't use the spread operator with `Array.push()`.
* To fix, I've simply replaced the spread operator with a simple `for` loop, which solves the issue.